### PR TITLE
Add additional properties to MessageCard and Section

### DIFF
--- a/MessageCardModel/Image.cs
+++ b/MessageCardModel/Image.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace MessageCardModel
+{
+    public class Image
+    {
+        [JsonProperty("image")]
+        public string Uri { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+    }
+}

--- a/MessageCardModel/MessageCard.cs
+++ b/MessageCardModel/MessageCard.cs
@@ -12,11 +12,14 @@ namespace MessageCardModel
         [JsonProperty("@context")]
         public const string Context = "http://schema.org/extensions";
 
-        [JsonProperty("themeColor")]
-        public string ThemeColor { get; set; }
+        [JsonProperty("originator")]
+        public string Originator { get; set; }
 
         [JsonProperty("summary")]
         public string Summary { get; set; }
+
+        [JsonProperty("themeColor")]
+        public string ThemeColor { get; set; }
 
         [JsonProperty("title")]
         public string Title { get; set; }

--- a/MessageCardModel/MessageCardModel.csproj
+++ b/MessageCardModel/MessageCardModel.csproj
@@ -7,7 +7,7 @@
     <Product>Message Card Model</Product>
     <Description>Message Cards are meant to provide easy to read, at-a-glance information that users can very quickly decipher and act upon when appropriate.
 This package help developer to design thier own Message Cards easier.</Description>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MessageCardModel/Section.cs
+++ b/MessageCardModel/Section.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using MessageCardModel.Actions;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace MessageCardModel
@@ -7,6 +8,9 @@ namespace MessageCardModel
     {
         [JsonProperty("title")]
         public string Title { get; set; }
+
+        [JsonProperty("startGroup")]
+        public bool IsStartGroup { get; set; } = false;
 
         [JsonProperty("activityTitle")]
         public string ActivityTitle { get; set; }
@@ -20,10 +24,19 @@ namespace MessageCardModel
         [JsonProperty("activityImage")]
         public string ActivityImage { get; set; }
 
+        [JsonProperty("heroImage")]
+        public Image HeroImage { get; set; }
+
         [JsonProperty("text")]
         public string Text { get; set; }
 
         [JsonProperty("facts")]
         public IEnumerable<Fact> Facts { get; set; }
+
+        [JsonProperty("images")]
+        public IEnumerable<Image> Images { get; set; }
+
+        [JsonProperty("potentialAction")]
+        public IEnumerable<IAction> Actions { get; set; }
     }
 }


### PR DESCRIPTION
Primarily adds properties which use the Image object.

These are missing properties as listed on https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference